### PR TITLE
Currency support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 /SPEC.md
 /dist
+**/default_currencies.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ dependencies = [
  "clap",
  "colored",
  "console_error_panic_hook",
+ "dirs",
  "eframe",
  "phf",
  "reqwest",
@@ -462,6 +463,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
 dependencies = [
  "adler32",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1666,6 +1687,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,7 +158,11 @@ dependencies = [
  "colored",
  "console_error_panic_hook",
  "eframe",
+ "phf",
+ "reqwest",
  "rust_decimal",
+ "serde",
+ "serde_json",
  "strum",
  "thiserror",
  "tracing-wasm",
@@ -563,6 +573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "epaint"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +614,15 @@ checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
 dependencies = [
  "cmake",
  "pkg-config",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -675,6 +703,54 @@ dependencies = [
  "cmake",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-io"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+
+[[package]]
+name = "futures-task"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-util"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -789,6 +865,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +902,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "http"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -847,6 +1013,18 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jni"
@@ -964,6 +1142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1172,24 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1136,6 +1338,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1404,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
+name = "openssl"
+version = "0.10.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,10 +1502,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -1322,6 +1627,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
 name = "raw-window-handle"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,6 +1669,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,6 +1732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
+name = "ryu"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
 name = "safe_arch"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,6 +1753,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1408,10 +1790,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -1422,6 +1830,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1462,6 +1893,21 @@ checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
 dependencies = [
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1509,6 +1955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +2007,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -1638,6 +2108,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +2157,12 @@ checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -1701,6 +2219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "ttf-parser"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +2264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +2290,16 @@ dependencies = [
  "same-file",
  "winapi",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
 ]
 
 [[package]]
@@ -2061,6 +2601,15 @@ dependencies = [
  "web-sys",
  "windows-sys",
  "x11-dl",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rust_decimal = "1.26.1"
 eframe = "0.19.0"
 thiserror = "1.0.32"
 colored = "2.0.0"
+phf = { version = "0.11.1", features = ["macros"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"
@@ -30,3 +31,8 @@ tracing-wasm = "0.2.1"
 
 [profile.release]
 opt-level = 2 # fast and small wasm
+
+[build-dependencies]
+reqwest = { version = "0.11.11", features = ["blocking", "json"] }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "calculator"
 version = "0.2.1"
 authors = ["david072"]
 description = "A calculator working with text inputs."
+edition = "2018"
 
 [lib]
 name = "calculator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ eframe = "0.19.0"
 thiserror = "1.0.32"
 colored = "2.0.0"
 phf = { version = "0.11.1", features = ["macros"] }
+dirs = "4.0.0"
+reqwest = { version = "0.11.11", features = ["json"] }
+serde = { version = "1.0.144", features = ["derive"] }
+serde_json = "1.0.85"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.7"

--- a/build.rs
+++ b/build.rs
@@ -22,8 +22,8 @@ fn main() -> reqwest::Result<()> {
             .json::<ApiResponse>()?;
 
     let mut output = String::new();
-    output += r#" use std::ops::Range;
-use common::{Result, ErrorType};
+    output += r#"use std::ops::Range;
+use crate::common::{Result, ErrorType};
 use phf::{Map, phf_map};
 
 const BASE_CURRENCY: &str = ""#;

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, david072
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::collections::HashMap;
+
+const OUTPUT_FILE: &str = "src/calculator/environment/default_currencies.rs";
+
+#[derive(serde::Deserialize, Debug)]
+struct ApiResponse {
+    base: String,
+    rates: HashMap<String, serde_json::Value>,
+}
+
+fn main() -> reqwest::Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let ApiResponse { base, rates } =
+        reqwest::blocking::get("https://api.exchangerate.host/latest?base=EUR")?
+            .json::<ApiResponse>()?;
+
+    let mut output = String::new();
+    output += r#" use std::ops::Range;
+use common::{Result, ErrorType};
+use phf::{Map, phf_map};
+
+const BASE_CURRENCY: &str = ""#;
+    output += &base;
+
+    output += r#"";
+static CURRENCIES: Map<&'static str, f64> = phf_map! {"#;
+
+    for (key, value) in rates {
+        output += "\n\t\"";
+        output += &key;
+        output.push('"');
+        output.push_str(" => ");
+
+        let num = value.as_f64().unwrap();
+        output += &num.to_string();
+        if num.fract() == 0.0 {
+            output += ".0";
+        }
+
+        output += ",";
+    }
+
+    output += r#"
+};
+
+pub fn is_currency(str: &str) -> bool {
+    CURRENCIES.contains_key(str)
+}
+
+pub fn convert(src_curr: &str, dst_curr: &str, n: f64, range: &Range<usize>) -> Result<f64> {
+    if src_curr == dst_curr { return Ok(n); }
+
+    let mut value = n;
+    // Convert to base currency if needed
+    if src_curr != BASE_CURRENCY {
+        value /= match CURRENCIES.get(src_curr) {
+            Some(v) => v,
+            None => return Err(ErrorType::UnknownIdentifier.with(range.clone())),
+        };
+    }
+    // Convert from base currency to dst currency if needed
+    if dst_curr != BASE_CURRENCY {
+        value *= match CURRENCIES.get(dst_curr) {
+            Some(v) => v,
+            None => return Err(ErrorType::UnknownIdentifier.with(range.clone())),
+        };
+    }
+
+    Ok(value)
+}"#;
+
+    std::fs::write(OUTPUT_FILE, output).expect("Could not write to file");
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,8 @@ struct ApiResponse {
 }
 
 fn main() -> reqwest::Result<()> {
-    if &std::env::var("PROFILE").unwrap_or_default() != "release" {
+    if &std::env::var("PROFILE").unwrap_or_default() != "release" &&
+        std::path::PathBuf::from(OUTPUT_FILE).try_exists().unwrap_or(false) {
         return Ok(());
     }
 

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,9 @@ struct ApiResponse {
 }
 
 fn main() -> reqwest::Result<()> {
-    println!("cargo:rerun-if-changed=build.rs");
+    if &std::env::var("PROFILE").unwrap_or_default() != "release" {
+        return Ok(());
+    }
 
     let ApiResponse { base, rates } =
         reqwest::blocking::get("https://api.exchangerate.host/latest?base=EUR")?

--- a/build.rs
+++ b/build.rs
@@ -22,15 +22,13 @@ fn main() -> reqwest::Result<()> {
             .json::<ApiResponse>()?;
 
     let mut output = String::new();
-    output += r#"use std::ops::Range;
-use crate::common::{Result, ErrorType};
-use phf::{Map, phf_map};
+    output += r#"use phf::{Map, phf_map};
 
-const BASE_CURRENCY: &str = ""#;
+pub const BASE_CURRENCY: &str = ""#;
     output += &base;
 
     output += r#"";
-static CURRENCIES: Map<&'static str, f64> = phf_map! {"#;
+pub static CURRENCIES: Map<&'static str, f64> = phf_map! {"#;
 
     for (key, value) in rates {
         output += "\n\t\"";
@@ -48,33 +46,7 @@ static CURRENCIES: Map<&'static str, f64> = phf_map! {"#;
     }
 
     output += r#"
-};
-
-pub fn is_currency(str: &str) -> bool {
-    CURRENCIES.contains_key(str)
-}
-
-pub fn convert(src_curr: &str, dst_curr: &str, n: f64, range: &Range<usize>) -> Result<f64> {
-    if src_curr == dst_curr { return Ok(n); }
-
-    let mut value = n;
-    // Convert to base currency if needed
-    if src_curr != BASE_CURRENCY {
-        value /= match CURRENCIES.get(src_curr) {
-            Some(v) => v,
-            None => return Err(ErrorType::UnknownIdentifier.with(range.clone())),
-        };
-    }
-    // Convert from base currency to dst currency if needed
-    if dst_curr != BASE_CURRENCY {
-        value *= match CURRENCIES.get(dst_curr) {
-            Some(v) => v,
-            None => return Err(ErrorType::UnknownIdentifier.with(range.clone())),
-        };
-    }
-
-    Ok(value)
-}"#;
+};"#;
 
     std::fs::write(OUTPUT_FILE, output).expect("Could not write to file");
     Ok(())

--- a/src/bin/main_gui.rs
+++ b/src/bin/main_gui.rs
@@ -12,7 +12,7 @@ extern crate calculator;
 use eframe::{CreationContext, egui, Frame, Theme};
 use egui::*;
 use calculator::{
-    calculate,
+    Calculator,
     Environment,
     CalculatorResultData,
     Format,
@@ -73,6 +73,7 @@ enum Line {
 }
 
 struct App {
+    calculator: Calculator,
     environment: Environment,
 
     source: String,
@@ -99,6 +100,7 @@ impl App {
     fn new(cc: &CreationContext<'_>) -> Self {
         cc.egui_ctx.set_visuals(Visuals::dark());
         App {
+            calculator: Calculator::new(),
             environment: Environment::new(),
             source_old: String::new(),
             source: String::new(),
@@ -123,7 +125,8 @@ impl App {
         let str = str.trim();
         if str.is_empty() { return Line::Empty; }
 
-        let result = calculate(str, &mut self.environment, Verbosity::None);
+        let result = self.calculator
+            .calculate(str, &mut self.environment, Verbosity::None);
 
         let mut function: Option<(String, usize)> = None;
         let mut color_segments: Vec<ColorSegment> = Vec::new();
@@ -263,10 +266,11 @@ impl App {
 
                                 let env = self.environment.clone();
                                 let name = function.0.clone();
+                                let currencies = self.calculator.currencies.clone();
 
                                 plot_ui.line(plot::Line::new(
                                     plot::PlotPoints::from_explicit_callback(move |x| {
-                                        let res = env.resolve_custom_function(&name, &[x]).unwrap();
+                                        let res = env.resolve_custom_function(&name, &[x], &currencies).unwrap();
                                         res.0
                                     }, .., 512)
                                 ).name(&function.0));

--- a/src/calculator/astgen/ast.rs
+++ b/src/calculator/astgen/ast.rs
@@ -10,6 +10,7 @@ use std::fmt::{Formatter, Display, Debug};
 use std::ops::Range;
 use crate::environment::units::convert;
 use crate::environment::units::Unit;
+use crate::environment::currencies::Currencies;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Operator {
@@ -144,7 +145,7 @@ impl AstNode {
         }
     }
 
-    pub fn apply(&mut self, operator: &Self, rhs: &mut Self) -> Result<()> {
+    pub fn apply(&mut self, operator: &Self, rhs: &mut Self, currencies: &Currencies) -> Result<()> {
         self.apply_modifiers()?;
         rhs.apply_modifiers()?;
 
@@ -160,7 +161,13 @@ impl AstNode {
                 return Ok(());
             }
 
-            *lhs = convert(self.unit.as_ref().unwrap(), rhs_value, *lhs, &full_range)?;
+            *lhs = convert(
+                self.unit.as_ref().unwrap(),
+                rhs_value,
+                *lhs,
+                currencies,
+                &full_range,
+            )?;
             self.unit = Some(rhs_value.clone());
             return Ok(());
         }
@@ -172,7 +179,13 @@ impl AstNode {
         if rhs.unit.is_some() && self.unit.is_none() {
             self.unit = rhs.unit.clone();
         } else if rhs.unit.is_some() && rhs.unit != self.unit {
-            rhs_value = convert(rhs.unit.as_ref().unwrap(), self.unit.as_ref().unwrap(), rhs_value, &full_range)?;
+            rhs_value = convert(
+                rhs.unit.as_ref().unwrap(),
+                self.unit.as_ref().unwrap(),
+                rhs_value,
+                currencies,
+                &full_range,
+            )?;
         }
 
         match op {

--- a/src/calculator/astgen/ast.rs
+++ b/src/calculator/astgen/ast.rs
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use ::Format;
+use crate::Format;
 use crate::common::*;
 use std::fmt::{Formatter, Display, Debug};
 use std::ops::Range;
-use ::environment::units::convert;
-use environment::units::Unit;
+use crate::environment::units::convert;
+use crate::environment::units::Unit;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Operator {

--- a/src/calculator/astgen/ast.rs
+++ b/src/calculator/astgen/ast.rs
@@ -4,13 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::Format;
-use crate::common::*;
 use std::fmt::{Formatter, Display, Debug};
 use std::ops::Range;
-use crate::environment::units::convert;
-use crate::environment::units::Unit;
-use crate::environment::currencies::Currencies;
+use crate::{
+    Format,
+    common::*,
+    environment::{
+        units::{convert, Unit},
+        currencies::Currencies,
+    },
+};
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Operator {

--- a/src/calculator/astgen/parser.rs
+++ b/src/calculator/astgen/parser.rs
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use ::Format;
-use ::astgen::ast::{AstNode, Operator, AstNodeData, AstNodeModifier};
-use ::astgen::tokenizer::{Token, TokenType};
-use ::common::*;
+use crate::Format;
+use crate::astgen::ast::{AstNode, Operator, AstNodeData, AstNodeModifier};
+use crate::astgen::tokenizer::{Token, TokenType};
+use crate::common::*;
 use strum::IntoEnumIterator;
 use std::mem;
-use ::environment::Environment;
-use environment::units::{get_prefix_power, is_prefix, is_unit, Unit};
+use crate::environment::Environment;
+use crate::environment::units::{get_prefix_power, is_prefix, is_unit, Unit};
 
 macro_rules! error {
     ($variant:ident($range:expr)) => {

--- a/src/calculator/astgen/parser.rs
+++ b/src/calculator/astgen/parser.rs
@@ -878,6 +878,9 @@ mod tests {
         let ast = calculation!("3km");
         assert_eq!(ast.len(), 1);
         assert_eq!(ast[0].unit.as_ref().unwrap().to_string(), "km");
+        let ast = calculation!("3EUR");
+        assert_eq!(ast.len(), 1);
+        assert_eq!(ast[0].unit.as_ref().unwrap().to_string(), "EUR");
         Ok(())
     }
 

--- a/src/calculator/astgen/parser.rs
+++ b/src/calculator/astgen/parser.rs
@@ -4,14 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::Format;
-use crate::astgen::ast::{AstNode, Operator, AstNodeData, AstNodeModifier};
-use crate::astgen::tokenizer::{Token, TokenType};
-use crate::common::*;
 use strum::IntoEnumIterator;
 use std::mem;
-use crate::environment::Environment;
-use crate::environment::units::{get_prefix_power, is_prefix, is_unit, Unit};
+use crate::{
+    Format,
+    astgen::ast::{AstNode, Operator, AstNodeData, AstNodeModifier},
+    astgen::tokenizer::{Token, TokenType},
+    common::*,
+    environment::{
+        Environment,
+        units::{get_prefix_power, is_prefix, is_unit, Unit},
+    },
+};
 
 macro_rules! error {
     ($variant:ident($range:expr)) => {
@@ -445,7 +449,7 @@ impl<'a> Parser<'a> {
                                 error!(ExpectedUnit(identifier.range));
                             }
                             return Ok(());
-                        },
+                        }
                     };
 
                     let mut unit = Unit(unit, None);

--- a/src/calculator/astgen/tokenizer.rs
+++ b/src/calculator/astgen/tokenizer.rs
@@ -5,7 +5,7 @@
  */
 
 use crate::common::*;
-use strum::{EnumIter};
+use strum::EnumIter;
 use std::ops::Range;
 
 #[derive(Debug, EnumIter, Clone, Copy, PartialEq, Eq)]

--- a/src/calculator/color.rs
+++ b/src/calculator/color.rs
@@ -6,7 +6,7 @@
 
 use std::ops::Range;
 use eframe::egui::Color32;
-use ::astgen::tokenizer::{Token, TokenType};
+use crate::astgen::tokenizer::{Token, TokenType};
 use self::TokenType::*;
 
 #[derive(Debug, Clone)]

--- a/src/calculator/engine.rs
+++ b/src/calculator/engine.rs
@@ -159,18 +159,17 @@ impl<'a> Engine<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use common::Result;
-    use parse;
-    use tokenize;
-    use ParserResult;
-    use environment::units::format as format_unit;
+    use crate::common::Result;
+    use crate::{parse, tokenize, ParserResult};
+    use crate::environment::units::format as format_unit;
 
     macro_rules! eval {
         ($str:expr) => {
             evaluate(
                 if let ParserResult::Calculation(ast) = parse(&tokenize($str)?, &Environment::new())? { ast }
                 else { panic!("Expected ParserResult::Calculation"); },
-                &Environment::new()
+                &Environment::new(),
+                &Currencies::none(),
             )
         }
     }

--- a/src/calculator/engine.rs
+++ b/src/calculator/engine.rs
@@ -5,12 +5,13 @@
  */
 
 use std::mem::{take, replace};
-use astgen::ast::Operator;
-use {match_ast_node, Format};
-use environment::{Environment, Variable};
-use astgen::ast::{AstNode, AstNodeData};
-use common::*;
-use environment::units::Unit;
+use crate::{
+    astgen::ast::{Operator, AstNode, AstNodeData},
+    match_ast_node,
+    Format,
+    environment::{Environment, Variable, units::Unit},
+    common::*,
+};
 
 pub struct CalculationResult {
     pub result: f64,
@@ -69,7 +70,7 @@ fn eval_functions(ast: &mut Vec<AstNode>, env: &Environment) -> Result<()> {
                         Err(ty) => return Err(ty.with(node.range.clone())),
                     }
                 } else {
-                    return Err(ty.with(node.range.clone()))
+                    return Err(ty.with(node.range.clone()));
                 }
             }
         };

--- a/src/calculator/engine.rs
+++ b/src/calculator/engine.rs
@@ -5,7 +5,14 @@
  */
 
 use std::mem::{take, replace};
-use crate::{astgen::ast::{Operator, AstNode, AstNodeData}, match_ast_node, Format, environment::{Environment, Variable, units::Unit}, common::*, Currencies};
+use crate::{
+    astgen::ast::{Operator, AstNode, AstNodeData},
+    match_ast_node,
+    Format,
+    environment::{Environment, Variable, units::Unit},
+    common::*,
+    Currencies,
+};
 
 pub struct CalculationResult {
     pub result: f64,

--- a/src/calculator/environment/currencies.rs
+++ b/src/calculator/environment/currencies.rs
@@ -5,15 +5,143 @@
  */
 
 use std::ops::Range;
-use common::Result;
-use environment::default_currencies;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use crate::common::{Result, ErrorType};
+use crate::environment::default_currencies;
+
+const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
+const CURRENCIES_FILE_NAME: &str = "currencies.txt";
+const CURRENCY_API_URL: &str = "https://api.exchangerate.host/latest?base=EUR";
+
+fn cache_folder_path() -> std::path::PathBuf {
+    dirs::cache_dir().unwrap().join(CRATE_NAME)
+}
+
+fn cache_file_path() -> std::path::PathBuf {
+    cache_folder_path().join(CURRENCIES_FILE_NAME)
+}
+
 
 pub fn is_currency(str: &str) -> bool {
     default_currencies::is_currency(str)
 }
 
-pub fn convert(src_curr: &str, dst_curr: &str, n: f64, range: &Range<usize>) -> Result<f64> {
-    if src_curr == dst_curr { return Ok(n); }
+#[derive(serde::Deserialize, Debug)]
+struct ApiResponse {
+    base: String,
+    rates: HashMap<String, f64>,
+}
 
-    default_currencies::convert(src_curr, dst_curr, n, range)
+pub struct Currencies {
+    base: Mutex<Option<String>>,
+    currencies: Mutex<Option<HashMap<String, f64>>>,
+}
+
+impl Currencies {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Currencies {
+        let (base, currencies) =
+            if let Some((base, currencies)) = Self::load_currencies() {
+                (Some(base), Some(currencies))
+            } else {
+                (None, None)
+            };
+
+        Currencies {
+            base: Mutex::new(base),
+            currencies: Mutex::new(currencies),
+        }
+    }
+
+    pub fn update_currencies(currencies: std::sync::Arc<Currencies>) {
+        std::thread::spawn(move || {
+            let ApiResponse { base, rates } =
+                reqwest::blocking::get(CURRENCY_API_URL).unwrap().json().unwrap();
+
+            let mut file_content = String::new();
+            file_content += &base;
+
+            for (name, num) in &rates {
+                file_content.push('\n');
+                file_content += name;
+                file_content.push(':');
+                file_content += &num.to_string();
+            }
+
+            *currencies.base.lock().unwrap() = Some(base);
+            *currencies.currencies.lock().unwrap() = Some(rates);
+
+            if !cache_folder_path().try_exists().unwrap_or(false) {
+                let _ = std::fs::create_dir(cache_folder_path());
+            }
+
+            let file = cache_file_path();
+            let _ = std::fs::write(file, file_content);
+        });
+    }
+
+    fn load_currencies() -> Option<(String, HashMap<String, f64>)> {
+        let file = cache_file_path();
+        if !file.try_exists().unwrap_or(false) { return None; }
+
+        let file_contents = match std::fs::read_to_string(file) {
+            Ok(contents) => contents,
+            Err(_) => return None,
+        };
+        if file_contents.is_empty() { return None; }
+
+        let mut result = HashMap::new();
+
+        let mut lines = file_contents.lines();
+        let base = lines.next().unwrap().to_owned();
+
+        for line in file_contents.lines() {
+            if line.is_empty() { continue; }
+            let parts = line.split(':').collect::<Vec<_>>();
+            if parts.len() != 2 { continue; }
+
+            let name = parts[0];
+            let num: f64 = match parts[1].parse() {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+
+            result.insert(name.to_string(), num);
+        }
+
+        Some((base, result))
+    }
+
+    pub fn convert(&self, src_curr: &str, dst_curr: &str, n: f64, range: &Range<usize>) -> Result<f64> {
+        if src_curr == dst_curr { return Ok(n); }
+
+        let base = &*self.base.lock().unwrap();
+        let currencies = &*self.currencies.lock().unwrap();
+
+        if base.is_none() || currencies.is_none() {
+            return default_currencies::convert(src_curr, dst_curr, n, range);
+        }
+
+        let base = base.as_ref().unwrap();
+        let currencies = currencies.as_ref().unwrap();
+
+        let mut value = n;
+        // Convert to base currency if needed
+        if src_curr != base {
+            value /= match currencies.get(src_curr) {
+                Some(v) => v,
+                None => return Err(ErrorType::UnknownIdentifier.with(range.clone())),
+            };
+        }
+        // Convert from base currency to dst currency if needed
+        if dst_curr != base {
+            value *= match currencies.get(dst_curr) {
+                Some(v) => v,
+                None => return Err(ErrorType::UnknownIdentifier.with(range.clone())),
+            };
+        }
+
+        Ok(value)
+    }
 }

--- a/src/calculator/environment/currencies.rs
+++ b/src/calculator/environment/currencies.rs
@@ -62,6 +62,7 @@ impl Currencies {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn update_currencies(currencies: std::sync::Arc<Currencies>) {
         std::thread::spawn(move || {
             let ApiResponse { base, rates } =
@@ -89,6 +90,11 @@ impl Currencies {
         });
     }
 
+    /// FIXME: Implement this
+    #[cfg(target_arch = "wasm32")]
+    pub fn update_currencies(_: std::sync::Arc<Currencies>) {}
+
+    #[cfg(not(target_arch = "wasm32"))]
     fn load_currencies() -> Option<(String, HashMap<String, f64>)> {
         let file = cache_file_path();
         if !file.try_exists().unwrap_or(false) { return None; }
@@ -120,6 +126,10 @@ impl Currencies {
 
         Some((base, result))
     }
+
+    /// FIXME: Implement this
+    #[cfg(target_arch = "wasm32")]
+    fn load_currencies() -> Option<(String, HashMap<String, f64>)> {}
 
     pub fn convert(&self, src_curr: &str, dst_curr: &str, n: f64, range: &Range<usize>) -> Result<f64> {
         if src_curr == dst_curr { return Ok(n); }

--- a/src/calculator/environment/currencies.rs
+++ b/src/calculator/environment/currencies.rs
@@ -55,6 +55,13 @@ impl Currencies {
         }
     }
 
+    pub fn none() -> Currencies {
+        Currencies {
+            base: Mutex::new(None),
+            currencies: Mutex::new(None),
+        }
+    }
+
     pub fn update_currencies(currencies: std::sync::Arc<Currencies>) {
         std::thread::spawn(move || {
             let ApiResponse { base, rates } =

--- a/src/calculator/environment/currencies.rs
+++ b/src/calculator/environment/currencies.rs
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, david072
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::ops::Range;
+use common::Result;
+use environment::default_currencies;
+
+pub fn is_currency(str: &str) -> bool {
+    default_currencies::is_currency(str)
+}
+
+pub fn convert(src_curr: &str, dst_curr: &str, n: f64, range: &Range<usize>) -> Result<f64> {
+    if src_curr == dst_curr { return Ok(n); }
+
+    default_currencies::convert(src_curr, dst_curr, n, range)
+}

--- a/src/calculator/environment/mod.rs
+++ b/src/calculator/environment/mod.rs
@@ -2,11 +2,14 @@ pub mod units;
 mod default_currencies;
 pub mod currencies;
 
-use crate::common::{ErrorType};
 use std::f64::consts::{PI, E, TAU};
-use crate::astgen::ast::AstNode;
+use crate::{
+    common::ErrorType,
+    Currencies,
+    evaluate,
+    astgen::ast::AstNode,
+};
 use self::units::Unit;
-use crate::{Currencies, evaluate};
 
 #[derive(Debug, Clone)]
 pub struct Variable(pub f64, pub Option<Unit>);

--- a/src/calculator/environment/mod.rs
+++ b/src/calculator/environment/mod.rs
@@ -6,7 +6,7 @@ use crate::common::{ErrorType};
 use std::f64::consts::{PI, E, TAU};
 use crate::astgen::ast::AstNode;
 use self::units::Unit;
-use crate::evaluate;
+use crate::{Currencies, evaluate};
 
 #[derive(Debug, Clone)]
 pub struct Variable(pub f64, pub Option<Unit>);
@@ -198,7 +198,7 @@ impl Environment {
         }
     }
 
-    pub fn resolve_custom_function(&self, f: &str, args: &[f64]) -> Result<(f64, Option<Unit>), ErrorType> {
+    pub fn resolve_custom_function(&self, f: &str, args: &[f64], currencies: &Currencies) -> Result<(f64, Option<Unit>), ErrorType> {
         for (name, Function(function_args, ast)) in &self.functions {
             if name == f {
                 let mut temp_env = Environment::new();
@@ -209,7 +209,7 @@ impl Environment {
                     temp_env.set_variable(&function_args[i], Variable(args[i], None))?;
                 }
 
-                let value = evaluate(ast.clone(), &temp_env);
+                let value = evaluate(ast.clone(), &temp_env, currencies);
                 for name in function_args { temp_env.remove_variable(name)?; }
 
                 return match value {

--- a/src/calculator/environment/mod.rs
+++ b/src/calculator/environment/mod.rs
@@ -2,11 +2,11 @@ pub mod units;
 mod default_currencies;
 pub mod currencies;
 
-use ::common::{ErrorType};
+use crate::common::{ErrorType};
 use std::f64::consts::{PI, E, TAU};
-use astgen::ast::AstNode;
+use crate::astgen::ast::AstNode;
 use self::units::Unit;
-use evaluate;
+use crate::evaluate;
 
 #[derive(Debug, Clone)]
 pub struct Variable(pub f64, pub Option<Unit>);

--- a/src/calculator/environment/mod.rs
+++ b/src/calculator/environment/mod.rs
@@ -1,4 +1,6 @@
 pub mod units;
+mod default_currencies;
+pub mod currencies;
 
 use ::common::{ErrorType};
 use std::f64::consts::{PI, E, TAU};

--- a/src/calculator/environment/mod.rs
+++ b/src/calculator/environment/mod.rs
@@ -1,4 +1,5 @@
 pub mod units;
+// This file will generated in build.rs at build time
 mod default_currencies;
 pub mod currencies;
 

--- a/src/calculator/environment/units.rs
+++ b/src/calculator/environment/units.rs
@@ -6,8 +6,8 @@
 
 use std::f64::consts::PI;
 use std::ops::Range;
-use common::{Result, ErrorType};
-use environment::currencies::{is_currency, convert as convert_currencies};
+use crate::common::{Result, ErrorType};
+use crate::environment::currencies::{is_currency, convert as convert_currencies};
 
 /// A struct representing a unit, holding a numerator and an optional denominator unit.
 ///

--- a/src/calculator/environment/units.rs
+++ b/src/calculator/environment/units.rs
@@ -7,7 +7,7 @@
 use std::f64::consts::PI;
 use std::ops::Range;
 use crate::common::{Result, ErrorType};
-use crate::environment::currencies::{is_currency, convert as convert_currencies};
+use crate::environment::currencies::{is_currency, Currencies};
 
 /// A struct representing a unit, holding a numerator and an optional denominator unit.
 ///
@@ -75,8 +75,8 @@ fn unit_prefix(unit: &str) -> Option<(char, i32)> {
     None
 }
 
-pub fn convert(src_unit: &Unit, dst_unit: &Unit, n: f64, range: &Range<usize>) -> Result<f64> {
-    let numerator = convert_units(&src_unit.0, &dst_unit.0, n, range)?;
+pub fn convert(src_unit: &Unit, dst_unit: &Unit, n: f64, currencies: &Currencies, range: &Range<usize>) -> Result<f64> {
+    let numerator = convert_units(&src_unit.0, &dst_unit.0, n, currencies, range)?;
 
     if src_unit.1.is_none() && dst_unit.1.is_none() {
         Ok(numerator)
@@ -85,6 +85,7 @@ pub fn convert(src_unit: &Unit, dst_unit: &Unit, n: f64, range: &Range<usize>) -
             src_unit.1.as_ref().unwrap(),
             dst_unit.1.as_ref().unwrap(),
             1.0,
+            currencies,
             range,
         )?;
         Ok(numerator / denominator)
@@ -95,7 +96,7 @@ pub fn convert(src_unit: &Unit, dst_unit: &Unit, n: f64, range: &Range<usize>) -
     }
 }
 
-fn convert_units(src_unit: &str, dst_unit: &str, n: f64, range: &Range<usize>) -> Result<f64> {
+fn convert_units(src_unit: &str, dst_unit: &str, n: f64, currencies: &Currencies, range: &Range<usize>) -> Result<f64> {
     if src_unit == dst_unit { return Ok(n); }
 
     let mut src_unit = src_unit;
@@ -345,7 +346,7 @@ fn convert_units(src_unit: &str, dst_unit: &str, n: f64, range: &Range<usize>) -
 
         ("K", "°C") => Ok(n - 273.15),
         ("K", "°F") => Ok((n - 273.15) * 9.0 / 5.0 + 32.0),
-        _ => convert_currencies(src_unit, dst_unit, n, range),
+        _ => currencies.convert(src_unit, dst_unit, n, range),
     }
 }
 

--- a/src/calculator/environment/units.rs
+++ b/src/calculator/environment/units.rs
@@ -6,8 +6,10 @@
 
 use std::f64::consts::PI;
 use std::ops::Range;
-use crate::common::{Result, ErrorType};
-use crate::environment::currencies::{is_currency, Currencies};
+use crate::{
+    common::{Result, ErrorType},
+    environment::currencies::{is_currency, Currencies},
+};
 
 /// A struct representing a unit, holding a numerator and an optional denominator unit.
 ///

--- a/src/calculator/environment/units.rs
+++ b/src/calculator/environment/units.rs
@@ -6,7 +6,8 @@
 
 use std::f64::consts::PI;
 use std::ops::Range;
-use ::common::{Result, ErrorType};
+use common::{Result, ErrorType};
+use environment::currencies::{is_currency, convert as convert_currencies};
 
 /// A struct representing a unit, holding a numerator and an optional denominator unit.
 ///
@@ -46,7 +47,7 @@ const PREFIXES: [(char, i32); 9] = [
 ];
 
 pub fn is_unit(str: &str) -> bool {
-    UNITS.contains(&str)
+    UNITS.contains(&str) || is_currency(str)
 }
 
 pub fn is_prefix(c: char) -> bool {
@@ -344,8 +345,7 @@ fn convert_units(src_unit: &str, dst_unit: &str, n: f64, range: &Range<usize>) -
 
         ("K", "°C") => Ok(n - 273.15),
         ("K", "°F") => Ok((n - 273.15) * 9.0 / 5.0 + 32.0),
-        _ => Err(ErrorType::UnknownConversion(
-            src_unit.to_string(), dst_unit.to_string()).with(range.clone())),
+        _ => convert_currencies(src_unit, dst_unit, n, range),
     }
 }
 

--- a/src/calculator/environment/units.rs
+++ b/src/calculator/environment/units.rs
@@ -94,7 +94,7 @@ pub fn convert(src_unit: &Unit, dst_unit: &Unit, n: f64, currencies: &Currencies
     } else {
         let src_unit = if let Some(u) = &src_unit.1 { u.clone() } else { String::new() };
         let dst_unit = if let Some(u) = &dst_unit.1 { u.clone() } else { String::new() };
-        Err(ErrorType::UnknownConversion( src_unit, dst_unit).with(range.clone()))
+        Err(ErrorType::UnknownConversion(src_unit, dst_unit).with(range.clone()))
     }
 }
 
@@ -376,8 +376,7 @@ fn format_unit(unit: &str, plural: bool) -> String {
     }
 
     let prefix = unit_prefix(unit).map(|x| x.0);
-    let unit = if prefix.is_some() { unit[1..].to_lowercase() } else { unit.to_lowercase() };
-    let unit = unit.as_str();
+    let unit = if prefix.is_some() { &unit[1..] } else { unit };
 
     let mut result = " ".to_string();
 
@@ -471,17 +470,24 @@ fn format_unit(unit: &str, plural: bool) -> String {
             // misc
             "cal" => "Calorie",
             "b" => "Byte",
-            _ => unreachable!(),
+            _ => ""
         };
 
-        if prefix.is_some() {
-            result.push_str(lowercase_first(singular).as_str());
-        } else {
-            result.push_str(singular);
-        }
+        if is_currency(unit) {
+            if result.len() - 1 != 0 { result.push(' '); }
+            result += unit;
+        } else if !singular.is_empty() {
+            if prefix.is_some() {
+                result.push_str(lowercase_first(singular).as_str());
+            } else {
+                result.push_str(singular);
+            }
 
-        if plural {
-            result.push('s');
+            if plural {
+                result.push('s');
+            }
+        } else {
+            unreachable!()
         }
     } else if prefix.is_some() {
         result.push_str(lowercase_first(unit_str).as_str());

--- a/src/calculator/mod.rs
+++ b/src/calculator/mod.rs
@@ -9,6 +9,7 @@ extern crate core;
 extern crate rust_decimal;
 extern crate eframe;
 extern crate thiserror;
+extern crate phf;
 
 mod astgen;
 mod common;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ extern crate colored;
 use clap::{Arg, ArgAction, Command};
 use std::io::{stdin, stdout, Write};
 use colored::Colorize;
-use calculator::{calculate, Environment, Verbosity, Format, round_dp, CalculatorResultData};
+use calculator::{Calculator, Environment, Verbosity, Format, round_dp, CalculatorResultData};
 
 const NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -38,6 +38,7 @@ fn main() {
         None => Verbosity::None,
     };
 
+    let calculator = Calculator::new();
     let mut environment = Environment::new();
 
     // TODO: Properly handle CTRL-C
@@ -52,7 +53,7 @@ fn main() {
         match input.as_str() {
             "quit" | "exit" => break,
             _ => {
-                match calculate(&input, &mut environment, verbosity) {
+                match calculator.calculate(&input, &mut environment, verbosity) {
                     Ok(res) => {
                         match res.data {
                             CalculatorResultData::Number { result: n, unit, format } => {


### PR DESCRIPTION
This adds support for currencies as units. The application now fetches the currency conversions from an [API](https://exchangerate.host) and stores them on desktop (see FIXMEs for WASM). Default conversions are also generated in build.rs during build time and stored in the file `src/calculator/environment/default_currencies.rs` and act as a fallback.